### PR TITLE
Use MenuStart messages for game mode selection

### DIFF
--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -31,20 +31,16 @@ local Update = function(af, delta)
 	end
 end
 
-local InputHandler = function(event)
-	if not event.PlayerNumber or not event.button then return false end
+local SelectGameMode = function()
+	if TopScreen:IsTransitioning() then return end
 
-	if event.type == "InputEventType_FirstPress" then
-		if event.GameButton == "Start" then
-			if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
-				SL.Global.GameMode = choices[cursor.index+1]
-				-- now that a GameMode has been selected, set related preferences
-				SetGameModePreferences()
-				-- and reload the theme's Metrics
-				THEME:ReloadMetrics()
-				SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
-			end
-		end
+	if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
+		SL.Global.GameMode = choices[cursor.index+1]
+		-- now that a GameMode has been selected, set related preferences
+		SetGameModePreferences()
+		-- and reload the theme's Metrics
+		THEME:ReloadMetrics()
+		TopScreen:StartTransitioningScreen("SM_GoToNextScreen")
 	end
 end
 
@@ -66,10 +62,11 @@ local t = Def.ActorFrame{
 			choices[#choices+1] = choice
 			choice_actors[#choice_actors+1] = TopScreen:GetChild("IconChoice"..choice)
 		end
-    	SCREENMAN:GetTopScreen():AddInputCallback(InputHandler)
 
 		self:queuecommand("Update")
 	end,
+	MenuStartP1MessageCommand=SelectGameMode,
+	MenuStartP2MessageCommand=SelectGameMode,
 	-- side mask
 	Def.Quad{
 		InitCommand=function(self) self:zoomto(450, 450):diffuse(1,1,1,1):x(375):MaskSource() end


### PR DESCRIPTION
Fixes #740 

The current handler just listens for the Start input directly but that won't detect the engine broadcast that happens when the timer expires. This PR uses the ``MenuStartP1``/``MenuStartP2`` messages instead which fixes it. 