### PR TITLE
Add menu timer option for pre-game selection screens

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -603,6 +603,7 @@ UseImageCache=ImageCache benutzen
 
 
 # MenuTimer Options
+PreGameMenuTimer=Auswahl vor dem Spiel
 ScreenSelectMusicMenuTimer=Musik Auswählen
 ScreenSelectMusicCasualMenuTimer=Musik Auswählen\nCasual Modus
 ScreenPlayerOptionsMenuTimer=Spieler Optionen
@@ -799,6 +800,7 @@ CustomSongsMaxMegabytes=If a song from a USB profile is larger than this file si
 
 # MenuTimer Options
 MenuTimer=When 'On', certain screens have a time limit, which you can set below.\n\nWhen 'Off', these values are ignored, and you may spend as much time on each screen as you need.
+PreGameMenuTimer=Legt den Menü-Timer-Wert für ScreenSelectColor, ScreenSelectStyle, ScreenSelectPlayMode und ScreenSelectPlayMode2 fest.
 ScreenSelectMusicMenuTimer=Set the MenuTimer value for ScreenSelectMusic.
 ScreenSelectMusicCasualMenuTimer=Set the MenuTimer value for ScreenSelectMusic when in 'Casual' mode.
 ScreenPlayerOptionsMenuTimer=Set the MenuTimer value for ScreenPlayerOptions.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -770,6 +770,7 @@ EnforceNoCmod=Enforce No Cmod
 
 # MenuTimer Options
 ScreenGrooveStatsLoginMenuTimer=GrooveStats Login
+PreGameMenuTimer=Pre-Game Selections
 ScreenSelectMusicMenuTimer=Select Music
 ScreenSelectMusicCasualMenuTimer=Select Music\nCasual Mode
 ScreenPlayerOptionsMenuTimer=Player Options
@@ -1007,6 +1008,7 @@ CustomSongsMaxMegabytes=If a song from a USB profile is larger than this file si
 # MenuTimer Options
 MenuTimer=When 'On', certain screens have a time limit, which you can set below.\n\nWhen 'Off', these values are ignored, and you may spend as much time on each screen as you need.
 ScreenGrooveStatsLoginMenuTimer=Set the MenuTimer value for GrooveStats login.
+PreGameMenuTimer=Set the MenuTimer value for ScreenSelectColor, ScreenSelectStyle, ScreenSelectPlayMode, and ScreenSelectPlayMode2.
 ScreenSelectMusicMenuTimer=Set the MenuTimer value for ScreenSelectMusic.
 ScreenSelectMusicCasualMenuTimer=Set the MenuTimer value for ScreenSelectMusic when in 'Casual' mode.
 ScreenPlayerOptionsMenuTimer=Set the MenuTimer value for ScreenPlayerOptions.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -711,6 +711,7 @@ KeyboardFeatures=Funciones con teclado
 UseImageCache=Usar ImageCache
 
 # MenuTimer Options
+PreGameMenuTimer=Selecciones previas al juego
 ScreenSelectMusicMenuTimer=Selección de Música
 ScreenSelectMusicCasualMenuTimer=Selección de Música\nModo Casual
 ScreenPlayerOptionsMenuTimer=Opciones de Jugador
@@ -906,6 +907,7 @@ CustomSongsMaxMegabytes=Si una canción adicional es más pesada que la cantidad
 
 #' MenuTimer Options
 MenuTimer=Cuando está "Activado", varias pantallas tendrán un limite de tiempo, que podrá configurar a continuación.\n\nCuando esté "Apagado", estos valores son ignorados, y podrá pasar el tiempo que necesite sin problemas.
+PreGameMenuTimer=Ajusta el valor del tiempo de menú para ScreenSelectColor, ScreenSelectStyle, ScreenSelectPlayMode y ScreenSelectPlayMode2.
 ScreenSelectMusicMenuTimer=Ajusta el limite de tiempo para ScreenSelectMusic.
 ScreenSelectMusicCasualMenuTimer=Ajusta el limite de tiempo para ScreenSelectMusic durante el modo 'Casual'.
 ScreenPlayerOptionsMenuTimer=Ajusta el limite de tiempo para ScreenPlayerOptions.

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -505,6 +505,7 @@ AllowThemeVideos=Autoriser les vidéos thématiques
 RainbowMode=Mode arc-en-ciel
 
 # MenuTimer Options
+PreGameMenuTimer=Sélections avant le jeu
 ScreenSelectMusicMenuTimer=Choix de musique
 ScreenSelectMusicCasualMenuTimer=Choix de musique\nen mode décontracté
 ScreenPlayerOptionsMenuTimer=Options de joueur
@@ -680,6 +681,7 @@ CustomSongsMaxMegabytes=Si une chanson est plus lourde que ce que ce réglage d�
 
 # MenuTimer Options
 MenuTimer=Quand ce réglage est activé, certains menus auront une limite de temps, réglables ci-dessous.\n\nQuand désactivé, les valeurs ci-dessous sont désactivées, et vous pouvez passer autant de temps que voulu dans chaque menu.
+PreGameMenuTimer=Définir la valeur du minuteur de menu pour les écrans de choix de couleur, de style, de mode de jeu et de marathon.
 ScreenSelectMusicMenuTimer=Définir le temps pour le choix de musique.
 ScreenSelectMusicCasualMenuTimer=Définir le temps pour le choix de musique, en mode décontacté.
 ScreenPlayerOptionsMenuTimer=Définir le temps pour le choix des options.

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -856,6 +856,7 @@ KeyboardFeatures=Funzionalità\nTastiera
 UseImageCache=Usa la cache Immagini
 
 # MenuTimer Options
+PreGameMenuTimer=Selezioni pre-partita
 ScreenSelectMusicMenuTimer=Selezione Canzone
 ScreenSelectMusicCasualMenuTimer=Selezione Canzone\nModalità Casual
 ScreenPlayerOptionsMenuTimer=Opzioni Giocatore
@@ -1157,6 +1158,7 @@ CustomSongsMaxMegabytes=Se un brano aggiuntivo supera il limite in megabyte impo
 
 # MenuTimer Options
 MenuTimer=Quando il timer è attivato, ogni schermata avrà un limite di tempo che è possibile configurare di seguito.\n\nQuando il timer è disattivato non ci sarà tempo limite in nessuna schermata; le impostazioni del timer di ogni singola schermata verranno ignorate.
+PreGameMenuTimer=Imposta il valore del timer del menu per le schermate di selezione del colore, dello stile, della modalità di gioco e della maratona.
 ScreenSelectMusicMenuTimer=Regola il limite di tempo per la schermata di selezione della canzone.
 ScreenSelectMusicCasualMenuTimer=Regola il limite di tempo per la schermata di selezione della musica durante la modalità 'Casual'.
 ScreenPlayerOptionsMenuTimer=Regola il limite di tempo per la schermata delle opzioni del giocatore.

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -609,6 +609,7 @@ RainbowMode=Rainbow Mode
 UseImageCache=Use ImageCache
 
 # MenuTimer Options
+PreGameMenuTimer=ゲーム開始前の選択
 ScreenSelectMusicMenuTimer=Select Music
 ScreenSelectMusicCasualMenuTimer=Select Music\nCasual Mode
 ScreenPlayerOptionsMenuTimer=Player Options
@@ -803,6 +804,7 @@ CustomSongsMaxMegabytes=USBカスタムソングの最大ファイルサイズ�
 
 # MenuTimer Options
 MenuTimer='On'にすると、各画面に制限時間が設けられます。各制限時間は以下で設定することができます。\n\n'Off'にすると、以下の設定項目は無視され、各画面の制限時間は無制限となります。
+PreGameMenuTimer=カラー、プレイスタイル、ゲームモード、マラソンの各選択画面のメニュータイマーを設定します。
 ScreenGrooveStatsLoginMenuTimer=Groovestatsログインの制限時間。
 ScreenSelectMusicMenuTimer=選曲画面の制限時間を指定します。
 ScreenSelectMusicCasualMenuTimer=Casualモードにおける、選曲画面の制限時間を指定します。

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -682,6 +682,7 @@ StepStats=Pokaż statystyki kroków
 EnforceNoCmod=Wymuś brak Cmod
 
 # Opcje Licznika Menu
+PreGameMenuTimer=Wybory przed grą
 ScreenSelectMusicMenuTimer=Wybór Utworu
 ScreenSelectMusicCasualMenuTimer=Wybór Utworu\n(Tryb Casual)
 ScreenPlayerOptionsMenuTimer=Opcje Gracza
@@ -902,6 +903,7 @@ CustomSongsMaxMegabytes=Gdy plik utworu ładowanego z USB jest większy niż ta 
 
 # Opcje Licznika Menu
 MenuTimer=Gdy włączony, niektóre ekrany mają ustalony limit czasowy, który można ustawić poniżej.\n\nGdy wyłączony, te wartości są ignorowane, więc nigdzie nie trzeba się śpieszyć.
+PreGameMenuTimer=Ustaw wartość licznika menu dla ekranów wyboru koloru, stylu, trybu gry i maratonu.
 ScreenSelectMusicMenuTimer=Wybierz wartość licznika menu dla wyboru utworu.
 ScreenSelectMusicCasualMenuTimer=Wybierz wartość licznika menu dla wyboru utworu w trybie casual.
 ScreenPlayerOptionsMenuTimer=Wybierz wartość licznika menu dla ekranu opcji gracza.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -1203,6 +1203,7 @@ RainbowMode=Modo Arcoíris
 UseImageCache=Usar ImageCache
 
 # MenuTimer Options
+PreGameMenuTimer=Seleções pré-jogo
 ScreenSelectMusicMenuTimer=Seleção de música
 ScreenSelectMusicCasualMenuTimer=Seleção de Música\nModo Casual
 ScreenPlayerOptionsMenuTimer=Opções de Jogador
@@ -1527,6 +1528,7 @@ CustomSongsMaxMegabytes=Se uma música adicional for mais pesada que o limite de
 
 #' MenuTimer Options
 MenuTimer=Quando está "Ligado", várias telas terão um limite de tempo, que você pode configurar em seguida.\n\nQuando está "Desativado", esses valores são ignorados e você pode gastar o tempo que precisa sem problemas.
+PreGameMenuTimer=Ajuste o limite de tempo para as telas de seleção de cor, estilo, modo de jogo e maratona.
 ScreenSelectMusicMenuTimer=Ajuste o limite de tempo para tela de seleção de música.
 ScreenSelectMusicCasualMenuTimer=Ajuste o limite de tempo para a tela de seleção de músicadurante o modo 'Casual'.
 ScreenPlayerOptionsMenuTimer=Ajuste o limite de tempo para tela de seleção das opções do jogador.

--- a/Languages/ru.ini
+++ b/Languages/ru.ini
@@ -673,6 +673,7 @@ StepStats=Статистика
 EnforceNoCmod=Отключить Cmod
 
 # MenuTimer Options
+PreGameMenuTimer=Выбор перед игрой
 ScreenSelectMusicMenuTimer=Выбор Песни
 ScreenSelectMusicCasualMenuTimer=Выбор песни:\nПростой Режим
 ScreenPlayerOptionsMenuTimer=Настройки Игры
@@ -892,6 +893,7 @@ CustomSongsMaxMegabytes=Если песня весит больше заданн
 
 # MenuTimer Options
 MenuTimer=Ограничить время, сколько можно находиться в каждом меню, перечисленном ниже.
+PreGameMenuTimer=Настройка таймера для экранов выбора цвета, стиля, режима игры и марафона.
 ScreenSelectMusicMenuTimer=Настройка таймера для выбора песен.
 ScreenSelectMusicCasualMenuTimer=Настройка таймера для выбора песен в простом режиме
 ScreenPlayerOptionsMenuTimer=Настройка таймера для выбора своих настроек.

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -200,6 +200,12 @@ SL_CustomPrefs.Get = function()
 			Choices = map(SecondsToMSS, range(15, 90, 5)),
 			Values  = range(15, 90, 5),
 		},
+		PreGameMenuTimer =
+		{
+			Default = 20,
+			Choices = map(SecondsToMSS, range(5, 90, 5)),
+			Values  = range(5, 90, 5),
+		},
 		ScreenSelectMusicMenuTimer =
 		{
 			Default = 300,

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -146,6 +146,7 @@ local GlobalDefaults = {
 			self.ScreenshotTexture = nil
 			self.MenuTimer = {
 				ScreenGrooveStatsLogin  = ThemePrefs.Get("ScreenGrooveStatsLoginMenuTimer"),
+				PreGame                 = ThemePrefs.Get("PreGameMenuTimer"),
 				ScreenSelectMusic       = ThemePrefs.Get("ScreenSelectMusicMenuTimer"),
 				ScreenSelectMusicCasual = ThemePrefs.Get("ScreenSelectMusicCasualMenuTimer"),
 				ScreenPlayerOptions     = ThemePrefs.Get("ScreenPlayerOptionsMenuTimer"),

--- a/metrics.ini
+++ b/metrics.ini
@@ -150,7 +150,7 @@ TimerSeconds=SL.Global.MenuTimer.ScreenGrooveStatsLogin
 Fallback="ScreenWithMenuElements"
 PrevScreen=Branch.TitleMenu()
 NextScreen=Branch.AfterScreenSelectColor()
-TimerSeconds=20
+TimerSeconds=SL.Global.MenuTimer.PreGame
 
 
 [ScreenSelectStyle]
@@ -158,7 +158,7 @@ Class="ScreenWithMenuElements"
 Fallback="ScreenWithMenuElements"
 PrevScreen=Branch.TitleMenu()
 NextScreen=Branch.AllowScreenSelectPlayMode()
-TimerSeconds=20
+TimerSeconds=SL.Global.MenuTimer.PreGame
 
 
 [ScreenSelectPlayMode]
@@ -167,7 +167,7 @@ Fallback="ScreenSelectMaster"
 PrevScreen=Branch.TitleMenu()
 NextScreen=Branch.AllowScreenSelectPlayMode2()
 ShowFooter=true
-TimerSeconds=20
+TimerSeconds=SL.Global.MenuTimer.PreGame
 
 ChoiceNames="Casual,ITG"
 ChoiceCasual="name,Casual"
@@ -1210,10 +1210,11 @@ LineAnimateBanners="lua,ThemePrefsRows.GetRow('AnimateBanners')"
 
 [ScreenMenuTimerOptions]
 Fallback="ScreenOptionsServiceChild"
-LineNames="MenuTimer,ScreenGrooveStatsLoginMenuTimer,ScreenSelectMusicMenuTimer,ScreenSelectMusicCasualMenuTimer,ScreenPlayerOptionsMenuTimer,ScreenEvaluationMenuTimer,ScreenEvaluationNonstopMenuTimer,ScreenEvaluationSummaryMenuTimer,ScreenNameEntryMenuTimer"
+LineNames="MenuTimer,ScreenGrooveStatsLoginMenuTimer,PreGameMenuTimer,ScreenSelectMusicMenuTimer,ScreenSelectMusicCasualMenuTimer,ScreenPlayerOptionsMenuTimer,ScreenEvaluationMenuTimer,ScreenEvaluationNonstopMenuTimer,ScreenEvaluationSummaryMenuTimer,ScreenNameEntryMenuTimer"
 
 LineMenuTimer="conf,MenuTimer"
 LineScreenGrooveStatsLoginMenuTimer="lua,ThemePrefsRows.GetRow('ScreenGrooveStatsLoginMenuTimer')"
+LinePreGameMenuTimer="lua,ThemePrefsRows.GetRow('PreGameMenuTimer')"
 LineScreenSelectMusicMenuTimer="lua,ThemePrefsRows.GetRow('ScreenSelectMusicMenuTimer')"
 LineScreenSelectMusicCasualMenuTimer="lua,ThemePrefsRows.GetRow('ScreenSelectMusicCasualMenuTimer')"
 LineScreenPlayerOptionsMenuTimer="lua,ThemePrefsRows.GetRow('ScreenPlayerOptionsMenuTimer')"


### PR DESCRIPTION
Currently they are hard coded to 20 seconds each with no ability to change it in the settings.

The same option is shared for color, style, gamemode, and marathon selection screens. 

The languages other than english were machine translated by gpt5.6 and then checked in google translate. 