### PR TITLE
Draws Sensor Debug State on Test Input

### DIFF
--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -207,6 +207,8 @@ return function(event)
 	end
 
 	if PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and event.type ~= "InputEventType_Repeat" then
+		-- inject per sensor state
+		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
 

--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -207,10 +207,11 @@ return function(event)
 	end
 
 	if PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and event.type ~= "InputEventType_Repeat" then
-		-- inject per sensor state
-		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
+
+	-- for debugging individual sensor states.
+	MESSAGEMAN:Broadcast("TestSensorEvent", INPUTFILTER:GetFullSensorState())
 
 	return false
 end

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/TestInput_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/TestInput_InputHandler.lua
@@ -15,10 +15,11 @@ local function input(event)
 
 	-- broadcast event data using MESSAGEMAN for the TestInput overlay to listen for
 	if event.type ~= "InputEventType_Repeat" then
-		-- inject per sensor state
-		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
+
+	-- for debugging individual sensor states.
+	MESSAGEMAN:Broadcast("TestSensorEvent", INPUTFILTER:GetFullSensorState())
 
 	-- pressing Start or Back (typically Esc on a keyboard) will queue "DirectInputToEngine"
 	-- but only if the event.type is not a Release

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/TestInput_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/TestInput_InputHandler.lua
@@ -15,6 +15,8 @@ local function input(event)
 
 	-- broadcast event data using MESSAGEMAN for the TestInput overlay to listen for
 	if event.type ~= "InputEventType_Repeat" then
+		-- inject per sensor state
+		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
 

--- a/BGAnimations/ScreenSelectMusic overlay/TestInput.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/TestInput.lua
@@ -6,8 +6,14 @@ if not (game=="dance" or game=="pump" or game=="techno") then return end
 local af = Def.ActorFrame{
 	Name="TestInput",
 	InitCommand=function(self) self:visible(false) end,
-	ShowTestInputCommand=function(self) self:visible(true) end,
-	HideTestInputCommand=function(self) self:visible(false) end,
+	ShowTestInputCommand=function(self) 
+		INPUTMAN:StartSensorTest()
+		self:visible(true) 
+	end,
+	HideTestInputCommand=function(self)
+		INPUTMAN:StopSensorTest()
+		self:visible(false) 
+	end,
 
 	Def.Quad{ InitCommand=function(self) self:FullScreen():diffuse(0,0,0,0.875) end },
 	LoadFont("Common Normal")..{

--- a/BGAnimations/ScreenTestInput underlay.lua
+++ b/BGAnimations/ScreenTestInput underlay.lua
@@ -13,6 +13,8 @@ local InputHandler = function(event)
 	end
 
 	if event.type ~= "InputEventType_Repeat" then
+		-- inject per sensor settings
+		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
 

--- a/BGAnimations/ScreenTestInput underlay.lua
+++ b/BGAnimations/ScreenTestInput underlay.lua
@@ -13,10 +13,11 @@ local InputHandler = function(event)
 	end
 
 	if event.type ~= "InputEventType_Repeat" then
-		-- inject per sensor settings
-		event.fullState = INPUTFILTER:GetFullSensorState()
 		MESSAGEMAN:Broadcast("TestInputEvent", event)
 	end
+	
+	-- for debugging individual sensor states.
+	MESSAGEMAN:Broadcast("TestSensorEvent", INPUTFILTER:GetFullSensorState())
 
 	if event.button == "" then
 		local key = ("%s %s"):format(ToEnumShortString(event.DeviceInput.device), ToEnumShortString(event.DeviceInput.button))

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -88,7 +88,7 @@ for panel,values in pairs(Highlights) do
 end
 
 -- Visual dimensions of an edge sensor.
-local EDGE_SENSOR_WIDTH = 28
+local EDGE_SENSOR_WIDTH = 26
 local EDGE_SENSOR_HEIGHT = 4
 local EDGE_POS_OFFSET = 28
 
@@ -115,8 +115,43 @@ local EdgeSensors = {
 		y = 0,
 		rotationz = 90,
 	},
-	Center = {
+		TopCenter = {
 		x = 0,
+		y = -EDGE_POS_OFFSET,
+		rotationz = 0,
+	},
+	TopLeft = {
+		x = -EDGE_POS_OFFSET * 0.707,
+		y = -EDGE_POS_OFFSET * 0.707,
+		rotationz = -45,
+	},
+	TopRight = {
+		x = EDGE_POS_OFFSET * 0.707,
+		y = -EDGE_POS_OFFSET * 0.707,
+		rotationz = 45,
+	},
+	RightCenter = {
+		x = EDGE_POS_OFFSET,
+		y = 0,
+		rotationz = 90,
+	},
+	BottomRight = {
+		x = EDGE_POS_OFFSET * 0.707,
+		y = EDGE_POS_OFFSET * 0.707,
+		rotationz = -45,
+	},
+	BottomCenter = {
+		x = 0,
+		y = EDGE_POS_OFFSET,
+		rotationz = 0,
+	},
+	BottomLeft = {
+		x = -EDGE_POS_OFFSET * 0.707,
+		y = EDGE_POS_OFFSET * 0.707,
+		rotationz = 45,
+	},
+	LeftCenter = {
+		x = -EDGE_POS_OFFSET,
 		y = 0,
 		rotationz = 90,
 	},

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -131,14 +131,14 @@ for panel, panel_values in pairs(Highlights) do
 				self:diffuse(0.7, 0.7, 0.7, 0)
 				self:visible(true)
 			end,
-			TestInputEventMessageCommand=function(self, event)
+			TestSensorEventMessageCommand=function(self, event)
 				-- event.fullState comes from the engine
-				if event.fullState ~= nil then
-					if event.fullState[PlayerNumberToString(player)][panel] ~= nil then
+				if event ~= nil then
+					if event[PlayerNumberToString(player)][panel] ~= nil then
 						-- intensity is the float of "how much" the panel is being pressed
 						-- for normal switches this could be just on/off
 						-- but for analog pads like fsrs it could be a range.
-						local intensity = event.fullState[PlayerNumberToString(player)][panel][sensor] or 0
+						local intensity = event[PlayerNumberToString(player)][panel][sensor] or 0
 						self:diffuse(0.7, 0.7, 0.7, intensity)
 					end
 				end

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -115,7 +115,28 @@ local EdgeSensors = {
 		y = 0,
 		rotationz = 90,
 	},
+	Center = {
+		x = 0,
+		y = 0,
+		rotationz = 90,
+	},
 }
+
+local function TestSensorEvent(self, event, player, panel, sensor)
+    if event == nil then
+        return
+    end
+
+    local playerState = event[PlayerNumberToString(player)]
+
+    if playerState == nil or playerState[panel] == nil then
+        return
+    end
+
+    local intensity = playerState[panel][sensor] or 0
+
+    self:diffuse(0.7, 0.7, 0.7, intensity)
+end
 
 -- render each sensor on top of the panel per player
 for panel, panel_values in pairs(Highlights) do
@@ -132,16 +153,10 @@ for panel, panel_values in pairs(Highlights) do
 				self:visible(true)
 			end,
 			TestSensorEventMessageCommand=function(self, event)
-				-- event.fullState comes from the engine
-				if event ~= nil then
-					if event[PlayerNumberToString(player)][panel] ~= nil then
-						-- intensity is the float of "how much" the panel is being pressed
-						-- for normal switches this could be just on/off
-						-- but for analog pads like fsrs it could be a range.
-						local intensity = event[PlayerNumberToString(player)][panel][sensor] or 0
-						self:diffuse(0.7, 0.7, 0.7, intensity)
-					end
-				end
+				TestSensorEvent(self, event, player, panel, sensor)
+			end,
+			TestSensorRedrawEventMessageCommand=function(self, event)
+				TestSensorEvent(self, INPUTFILTER:GetFullSensorState(), player, panel, sensor)
 			end,
 		}
 	end

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -87,6 +87,66 @@ for panel,values in pairs(Highlights) do
 	}
 end
 
+-- Visual dimensions of an edge sensor.
+local EDGE_SENSOR_WIDTH = 28
+local EDGE_SENSOR_HEIGHT = 4
+local EDGE_POS_OFFSET = 28
+
+-- Four edge sensors for each dance panel.
+-- Offsets are relative to the center of the panel.
+local EdgeSensors = {
+	Top = {
+		x = 0,
+		y = -EDGE_POS_OFFSET,
+		rotationz = 0,
+	},
+	Right = {
+		x = EDGE_POS_OFFSET,
+		y = 0,
+		rotationz = 90,
+	},
+	Bottom = {
+		x = 0,
+		y = EDGE_POS_OFFSET,
+		rotationz = 0,
+	},
+	Left = {
+		x = -EDGE_POS_OFFSET,
+		y = 0,
+		rotationz = 90,
+	},
+}
+
+-- render each sensor on top of the panel per player
+for panel, panel_values in pairs(Highlights) do
+	for sensor, sensor_values in pairs(EdgeSensors) do
+		pad[#pad+1] = Def.Quad {
+			InitCommand=function(self)
+				self:xy(
+					panel_values.x + sensor_values.x,
+					panel_values.y + sensor_values.y
+				)
+				self:rotationz(sensor_values.rotationz)
+				self:setsize(EDGE_SENSOR_WIDTH, EDGE_SENSOR_HEIGHT)
+				self:diffuse(0.7, 0.7, 0.7, 0)
+				self:visible(true)
+			end,
+			TestInputEventMessageCommand=function(self, event)
+				-- event.fullState comes from the engine
+				if event.fullState ~= nil then
+					if event.fullState[PlayerNumberToString(player)][panel] ~= nil then
+						-- intensity is the float of "how much" the panel is being pressed
+						-- for normal switches this could be just on/off
+						-- but for analog pads like fsrs it could be a range.
+						local intensity = event.fullState[PlayerNumberToString(player)][panel][sensor] or 0
+						self:diffuse(0.7, 0.7, 0.7, intensity)
+					end
+				end
+			end,
+		}
+	end
+end
+
 af[#af+1] = pad
 
 return af

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -92,30 +92,11 @@ local EDGE_SENSOR_WIDTH = 26
 local EDGE_SENSOR_HEIGHT = 4
 local EDGE_POS_OFFSET = 28
 
--- Four edge sensors for each dance panel.
+-- Edge sensors for each dance panel.
 -- Offsets are relative to the center of the panel.
+-- 0.707 is ~ 1/sqrt(2) for the diagonals.
 local EdgeSensors = {
-	Top = {
-		x = 0,
-		y = -EDGE_POS_OFFSET,
-		rotationz = 0,
-	},
-	Right = {
-		x = EDGE_POS_OFFSET,
-		y = 0,
-		rotationz = 90,
-	},
-	Bottom = {
-		x = 0,
-		y = EDGE_POS_OFFSET,
-		rotationz = 0,
-	},
-	Left = {
-		x = -EDGE_POS_OFFSET,
-		y = 0,
-		rotationz = 90,
-	},
-		TopCenter = {
+	TopCenter = {
 		x = 0,
 		y = -EDGE_POS_OFFSET,
 		rotationz = 0,


### PR DESCRIPTION
Preforms the following actions
- During test input, the engine is asked for a table using `INPUTFILTER:GetFullSensorState()` that will give the entire state of both player's individual switch sensor states in a float manner. When polled, an event is broadcasted using `TestSensorEvent`.
- New quads that represent the sensors are drawn and listen to this message. They adjust their opacity based on the float value in the table. This allows for analog sensors in the future, but for now they represent old style switches quite well.
- Ensures that `INPUTMAN:StartSensorTest()` and `INPUTMAN:StopSensorTest()` is called when the test screen is shown during gameplay in case the engine needs to do additional work to get this input state as we may not be on `ScreenTestInput`.

Sample view:
<img width="384" height="389" alt="image" src="https://github.com/user-attachments/assets/791c3fb9-6472-4fd8-8dd5-288225ed8886" />
<img width="823" height="547" alt="image" src="https://github.com/user-attachments/assets/509e8601-aeea-4740-b2b2-8faa3ba35474" />


Requires engine changes here: https://github.com/itgmania/itgmania/pull/1472