### PR TITLE
More reasonable choices for USB operator settings

### DIFF
--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -369,6 +369,36 @@ OperatorMenuOptionRows.MemoryCards = function()
 	}
 end
 
+OperatorMenuOptionRows.CustomSongsMaxCount = function()
+	local choices = {10, 25, 50, 100, 150, 300, 500, 1000, 2000}
+
+	-- accommodate custom values rather than steamrolling over them
+	local pref = PREFSMAN:GetPreference("CustomSongsMaxCount")
+	if not FindInTable(pref, choices) then table.insert(choices, pref) end
+
+	return {
+		Name="CustomSongsMaxCount",
+		Choices=choices,
+		LayoutType = "ShowAllInRow",
+		SelectType = "SelectOne",
+		OneChoiceForAllPlayers = true,
+		ExportOnChange = false,
+		LoadSelections = function(self, list, pn)
+			local pref = PREFSMAN:GetPreference("CustomSongsMaxCount")
+			local i = FindInTable(pref, choices) or 1
+			list[i] = true
+		end,
+		SaveSelections = function(self, list, pn)
+			for i=1, #choices do
+				if list[i] then
+					PREFSMAN:SetPreference("CustomSongsMaxCount", choices[i])
+					break
+				end
+			end
+		end,
+	}
+end
+
 
 OperatorMenuOptionRows.CustomSongsMaxSeconds = function()
 	-- first, define a reasonable range of 1:45 to 15:00

--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -445,9 +445,7 @@ OperatorMenuOptionRows.CustomSongsMaxMegabytes = function()
 end
 
 OperatorMenuOptionRows.CustomSongsLoadTimeout = function()
-	-- first, define a reasonable range of integers from [3,10]
-	local choices = range(3,10)
-	table.insert(choices, 60)
+	local choices = {3, 5, 7, 10, 15, 30, 60, 90, 120}
 
 	-- accommodate custom values rather than steamrolling over them
 	local pref = PREFSMAN:GetPreference("CustomSongsLoadTimeout")

--- a/metrics.ini
+++ b/metrics.ini
@@ -1228,7 +1228,7 @@ LineNames="MemoryCards,CustomSongs,MaxCount,CustomSongsLoadTimeout,CustomSongsMa
 
 LineMemoryCards="lua,OperatorMenuOptionRows.MemoryCards()"
 LineCustomSongs="conf,CustomSongsEnable"
-LineMaxCount="conf,CustomSongsMaxCount"
+LineMaxCount="lua,OperatorMenuOptionRows.CustomSongsMaxCount()"
 LineCustomSongsLoadTimeout="lua,OperatorMenuOptionRows.CustomSongsLoadTimeout()"
 LineCustomSongsMaxSeconds="lua,OperatorMenuOptionRows.CustomSongsMaxSeconds()"
 LineCustomSongsMaxMegabytes="lua,OperatorMenuOptionRows.CustomSongsMaxMegabytes()"


### PR DESCRIPTION
As mentioned in #776 the usb timeout values seem a bit weird with the context of how the setting actually works.
The adjusted timeout values are:
``3, 5, 7, 10, 15, 30, 60, 90, 120``

I also adjusted the max custom songs values to be (imo) more nice options of 
``10, 25, 50, 100, 150, 300, 500, 1000, 2000``
instead of the engine default of
``10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000``

This should be in the same release as https://github.com/itgmania/itgmania/pull/1469